### PR TITLE
feat: add timer component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
+import Timer from '../components/Timer';
 
 const ALL_ANIMALS = [
   'lion',
@@ -50,6 +51,7 @@ export default function Page() {
   return (
     <main>
       <h1>Animal Quiz</h1>
+      <Timer />
       <form onSubmit={handleSubmit}>
         <input
           ref={inputRef}

--- a/components/Timer.tsx
+++ b/components/Timer.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export default function Timer() {
+  const [seconds, setSeconds] = useState(0);
+  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout | undefined;
+    if (running) {
+      interval = setInterval(() => {
+        setSeconds((s) => s + 1);
+      }, 1000);
+    }
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [running]);
+
+  const start = () => setRunning(true);
+  const stop = () => setRunning(false);
+
+  return (
+    <div>
+      <div>Time: {seconds}s</div>
+      <button onClick={start} disabled={running}>
+        Start
+      </button>
+      <button onClick={stop} disabled={!running}>
+        Stop
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a simple timer component
- show timer on quiz page with start and stop buttons

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a1816270f88330991541bdcc1ceb35