### PR TITLE
Add give-up option to reveal quiz answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A basic Next.js site scaffold for Quizzler.
 
+Type the names of the animals to guess them. If you get stuck, hit the **Give Up** button to reveal all of the answers.
+
 ## Getting Started
 
 Install dependencies (requires internet access):

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -24,6 +24,7 @@ export default function Page() {
   const [quizAnimals, setQuizAnimals] = useState<string[]>([]);
   const [guessed, setGuessed] = useState<string[]>([]);
   const [guess, setGuess] = useState('');
+  const [revealed, setRevealed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -58,10 +59,19 @@ export default function Page() {
           onChange={(e) => setGuess(e.target.value)}
           autoFocus
         />
+        <button
+          type="button"
+          onClick={() => setRevealed(true)}
+          disabled={revealed}
+          style={{ marginLeft: '8px' }}
+        >
+          Give Up
+        </button>
       </form>
       <div style={{ marginTop: '1rem' }}>
         {quizAnimals.map((animal, index) => {
           const isGuessed = guessed.includes(animal);
+          const showAnimal = isGuessed || revealed;
           return (
             <span
               key={index}
@@ -69,7 +79,7 @@ export default function Page() {
                 display: 'inline-block',
                 width: '100px',
                 height: '30px',
-                backgroundColor: isGuessed ? '#fff' : '#000',
+                backgroundColor: showAnimal ? '#fff' : '#000',
                 color: '#000',
                 marginRight: '8px',
                 marginBottom: '8px',
@@ -78,14 +88,16 @@ export default function Page() {
                 border: '1px solid #000',
               }}
             >
-              {isGuessed ? animal : ''}
+              {showAnimal ? animal : ''}
             </span>
           );
         })}
       </div>
       <p>
-        Correct: {guessed.length} | Remaining: {quizAnimals.length - guessed.length}
+        Correct: {guessed.length} | Remaining:{' '}
+        {revealed ? 0 : quizAnimals.length - guessed.length}
       </p>
+      {revealed && <p>You gave up! Answers revealed.</p>}
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- allow quiz takers to reveal all answers via a Give Up button
- document the new Give Up behavior in the README

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a181398ca88330b6a1d512985a2920