### PR TITLE
feat: add quiz selector component

### DIFF
--- a/app/components/QuizSelector.tsx
+++ b/app/components/QuizSelector.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+import { Quiz } from '../data/quizzes';
+
+interface QuizSelectorProps {
+  quizzes: Quiz[];
+  onSelect: (quizId: string) => void;
+}
+
+export default function QuizSelector({ quizzes, onSelect }: QuizSelectorProps) {
+  return (
+    <select defaultValue="" onChange={(e) => onSelect(e.target.value)}>
+      <option value="" disabled>
+        Choose a quiz
+      </option>
+      {quizzes.map((quiz) => (
+        <option key={quiz.id} value={quiz.id}>
+          {quiz.title}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/data/quizzes.ts
+++ b/app/data/quizzes.ts
@@ -1,0 +1,10 @@
+export interface Quiz {
+  id: string;
+  title: string;
+}
+
+export const quizzes: Quiz[] = [
+  { id: 'math', title: 'Math Quiz' },
+  { id: 'science', title: 'Science Quiz' },
+  { id: 'history', title: 'History Quiz' },
+];

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,17 @@
+'use client';
+
+import { useState } from 'react';
+import QuizSelector from './components/QuizSelector';
+import { quizzes } from './data/quizzes';
+
 export default function Page() {
-  return <h1>Welcome to Quizzler</h1>;
+  const [selected, setSelected] = useState<string | null>(null);
+
+  return (
+    <div>
+      <h1>Welcome to Quizzler</h1>
+      <QuizSelector quizzes={quizzes} onSelect={setSelected} />
+      {selected && <p>Selected quiz: {selected}</p>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add `QuizSelector` component to list available quizzes and emit selection
- provide static quiz data
- update page to show selected quiz

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a1804d23b08330a073c641263a3eb1