### PR TITLE
feat: add quiz selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A basic Next.js site scaffold for Quizzler.
 
-Type the names of the animals to guess them. If you get stuck, hit the **Give Up** button to reveal all of the answers.
+Select a quiz topic from the drop-down and type the names to guess them. If you get stuck, hit the **Give Up** button to reveal all of the answers.
 
 ## Getting Started
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,46 +2,32 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Timer from '../components/Timer';
-
-const ALL_ANIMALS = [
-  'lion',
-  'tiger',
-  'elephant',
-  'giraffe',
-  'zebra',
-  'bear',
-  'wolf',
-  'fox',
-  'monkey',
-  'penguin',
-  'kangaroo',
-  'panda',
-  'otter',
-  'koala',
-  'rabbit',
-];
+import { QUIZZES, QuizKey } from '../quizzes';
 
 export default function Page() {
-  const [quizAnimals, setQuizAnimals] = useState<string[]>([]);
+  const [quizKey, setQuizKey] = useState<QuizKey>('animals');
+  const [quizItems, setQuizItems] = useState<string[]>([]);
   const [guessed, setGuessed] = useState<string[]>([]);
   const [guess, setGuess] = useState('');
   const [revealed, setRevealed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const shuffled = [...ALL_ANIMALS].sort(() => Math.random() - 0.5);
-    setQuizAnimals(shuffled.slice(0, 5));
-  }, []);
+    const shuffled = [...QUIZZES[quizKey]].sort(() => Math.random() - 0.5);
+    setQuizItems(shuffled.slice(0, 5));
+    setGuessed([]);
+    setRevealed(false);
+  }, [quizKey]);
 
   useEffect(() => {
     inputRef.current?.focus();
-  }, []);
+  }, [quizKey]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const normalized = guess.trim().toLowerCase();
     if (
-      quizAnimals.some((a) => a === normalized) &&
+      quizItems.some((a) => a === normalized) &&
       !guessed.includes(normalized)
     ) {
       setGuessed([...guessed, normalized]);
@@ -51,7 +37,18 @@ export default function Page() {
 
   return (
     <main>
-      <h1>Animal Quiz</h1>
+      <h1>{quizKey.charAt(0).toUpperCase() + quizKey.slice(1)} Quiz</h1>
+      <select
+        value={quizKey}
+        onChange={(e) => setQuizKey(e.target.value as QuizKey)}
+        style={{ marginBottom: '8px' }}
+      >
+        {Object.keys(QUIZZES).map((key) => (
+          <option key={key} value={key}>
+            {key.charAt(0).toUpperCase() + key.slice(1)}
+          </option>
+        ))}
+      </select>
       <Timer />
       <form onSubmit={handleSubmit}>
         <input
@@ -71,9 +68,9 @@ export default function Page() {
         </button>
       </form>
       <div style={{ marginTop: '1rem' }}>
-        {quizAnimals.map((animal, index) => {
-          const isGuessed = guessed.includes(animal);
-          const showAnimal = isGuessed || revealed;
+        {quizItems.map((item, index) => {
+          const isGuessed = guessed.includes(item);
+          const showItem = isGuessed || revealed;
           return (
             <span
               key={index}
@@ -81,7 +78,7 @@ export default function Page() {
                 display: 'inline-block',
                 width: '100px',
                 height: '30px',
-                backgroundColor: showAnimal ? '#fff' : '#000',
+                backgroundColor: showItem ? '#fff' : '#000',
                 color: '#000',
                 marginRight: '8px',
                 marginBottom: '8px',
@@ -90,14 +87,14 @@ export default function Page() {
                 border: '1px solid #000',
               }}
             >
-              {showAnimal ? animal : ''}
+              {showItem ? item : ''}
             </span>
           );
         })}
       </div>
       <p>
         Correct: {guessed.length} | Remaining:{' '}
-        {revealed ? 0 : quizAnimals.length - guessed.length}
+        {revealed ? 0 : quizItems.length - guessed.length}
       </p>
       {revealed && <p>You gave up! Answers revealed.</p>}
     </main>

--- a/quizzes/animals.ts
+++ b/quizzes/animals.ts
@@ -1,0 +1,17 @@
+export default [
+  'lion',
+  'tiger',
+  'elephant',
+  'giraffe',
+  'zebra',
+  'bear',
+  'wolf',
+  'fox',
+  'monkey',
+  'penguin',
+  'kangaroo',
+  'panda',
+  'otter',
+  'koala',
+  'rabbit',
+];

--- a/quizzes/countries.ts
+++ b/quizzes/countries.ts
@@ -1,0 +1,12 @@
+export default [
+  'canada',
+  'brazil',
+  'france',
+  'india',
+  'australia',
+  'kenya',
+  'japan',
+  'mexico',
+  'germany',
+  'egypt',
+];

--- a/quizzes/foods.ts
+++ b/quizzes/foods.ts
@@ -1,0 +1,12 @@
+export default [
+  'pizza',
+  'sushi',
+  'hamburger',
+  'spaghetti',
+  'curry',
+  'sandwich',
+  'salad',
+  'tacos',
+  'chocolate',
+  'pancake',
+];

--- a/quizzes/index.ts
+++ b/quizzes/index.ts
@@ -1,0 +1,11 @@
+import animals from './animals';
+import countries from './countries';
+import foods from './foods';
+
+export const QUIZZES = {
+  animals,
+  countries,
+  foods,
+};
+
+export type QuizKey = keyof typeof QUIZZES;


### PR DESCRIPTION
## Summary
- convert landing page to support multiple quizzes
- expose animals, countries and foods in new quizzes folder
- add dropdown selector for switching between quizzes

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68a1f70fd1008330802ae5cd3602cf61