### PR TITLE
Add per-letter hidden answer component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import Timer from '../components/Timer';
+import HiddenAnswer from '../components/HiddenAnswer';
 import { QUIZZES, QuizKey } from '../quizzes';
 
 export default function Page() {
@@ -72,23 +73,20 @@ export default function Page() {
           const isGuessed = guessed.includes(item);
           const showItem = isGuessed || revealed;
           return (
-            <span
+            <div
               key={index}
               style={{
                 display: 'inline-block',
-                width: '100px',
-                height: '30px',
-                backgroundColor: showItem ? '#fff' : '#000',
-                color: '#000',
                 marginRight: '8px',
                 marginBottom: '8px',
-                lineHeight: '30px',
-                textAlign: 'center',
-                border: '1px solid #000',
               }}
             >
-              {showItem ? item : ''}
-            </span>
+              <HiddenAnswer
+                answer={item}
+                reveal={showItem}
+                orientation={index % 2 === 0 ? 'horizontal' : 'vertical'}
+              />
+            </div>
           );
         })}
       </div>

--- a/components/HiddenAnswer.tsx
+++ b/components/HiddenAnswer.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface HiddenAnswerProps {
+  answer: string;
+  reveal?: boolean;
+  orientation?: 'horizontal' | 'vertical';
+}
+
+export default function HiddenAnswer({
+  answer,
+  reveal = false,
+  orientation = 'horizontal',
+}: HiddenAnswerProps) {
+  const letters = answer.split('');
+  const [revealedLetters, setRevealedLetters] = useState<boolean[]>(() =>
+    letters.map(() => false),
+  );
+
+  useEffect(() => {
+    if (reveal) {
+      setRevealedLetters(letters.map(() => true));
+    }
+  }, [reveal, letters]);
+
+  const revealLetter = (index: number) => {
+    setRevealedLetters((prev) =>
+      prev.map((val, i) => (i === index ? true : val)),
+    );
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: orientation === 'vertical' ? 'column' : 'row',
+      }}
+    >
+      {letters.map((char, idx) => (
+        <span
+          key={idx}
+          onClick={() => revealLetter(idx)}
+          style={{
+            display: 'inline-block',
+            width: '20px',
+            height: '30px',
+            marginRight: orientation === 'horizontal' ? '4px' : 0,
+            marginBottom: orientation === 'vertical' ? '4px' : 0,
+            backgroundColor: revealedLetters[idx] ? 'transparent' : '#000',
+            color: '#000',
+            textAlign: 'center',
+            lineHeight: '30px',
+            border: '1px solid #000',
+            cursor:
+              reveal || revealedLetters[idx] ? 'default' : 'pointer',
+          }}
+        >
+          {revealedLetters[idx] ? char : ''}
+        </span>
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce `HiddenAnswer` component that reveals letters individually and supports horizontal or vertical layout
- use `HiddenAnswer` in quiz page instead of single span

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_68a21420bebc8330a519312439fb739b