### PR TITLE
Remove quiz item limit

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ export default function Page() {
 
   useEffect(() => {
     const shuffled = [...QUIZZES[quizKey]].sort(() => Math.random() - 0.5);
-    setQuizItems(shuffled.slice(0, 5));
+    setQuizItems(shuffled);
     setGuessed([]);
     setRevealed(false);
   }, [quizKey]);


### PR DESCRIPTION
## Summary
- Show every quiz option by removing the five-item slice from quiz initialization

## Testing
- `npm test`
- `npm run lint` *(fails: next lint prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a216d5700c8330a13fbfcd83986b91