### PR TITLE
feat: add stats component

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import Timer from '../components/Timer';
+import Stats from '../components/Stats';
 import HiddenAnswer from '../components/HiddenAnswer';
 import { QUIZZES, QuizKey } from '../quizzes';
 
@@ -36,6 +36,8 @@ export default function Page() {
     setGuess('');
   };
 
+  const remaining = revealed ? 0 : quizItems.length - guessed.length;
+
   return (
     <main>
       <h1>{quizKey.charAt(0).toUpperCase() + quizKey.slice(1)} Quiz</h1>
@@ -50,7 +52,7 @@ export default function Page() {
           </option>
         ))}
       </select>
-      <Timer />
+      <Stats remaining={remaining} guesses={guessed.length} />
       <form onSubmit={handleSubmit}>
         <input
           ref={inputRef}
@@ -90,10 +92,6 @@ export default function Page() {
           );
         })}
       </div>
-      <p>
-        Correct: {guessed.length} | Remaining:{' '}
-        {revealed ? 0 : quizItems.length - guessed.length}
-      </p>
       {revealed && <p>You gave up! Answers revealed.</p>}
     </main>
   );

--- a/components/RemainingAnswers.tsx
+++ b/components/RemainingAnswers.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+interface RemainingAnswersProps {
+  remaining: number;
+}
+
+export default function RemainingAnswers({ remaining }: RemainingAnswersProps) {
+  return <div>Remaining: {remaining}</div>;
+}

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import Timer from './Timer';
+import RemainingAnswers from './RemainingAnswers';
+import TotalGuesses from './TotalGuesses';
+
+interface StatsProps {
+  remaining: number;
+  guesses: number;
+}
+
+export default function Stats({ remaining, guesses }: StatsProps) {
+  return (
+    <div>
+      <Timer />
+      <RemainingAnswers remaining={remaining} />
+      <TotalGuesses total={guesses} />
+    </div>
+  );
+}

--- a/components/TotalGuesses.tsx
+++ b/components/TotalGuesses.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+interface TotalGuessesProps {
+  total: number;
+}
+
+export default function TotalGuesses({ total }: TotalGuessesProps) {
+  return <div>Guesses: {total}</div>;
+}


### PR DESCRIPTION
## Summary
- create Stats component with timer, remaining answers, and guess count
- use Stats in quiz page

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68a21aadecdc83309923cf6280069eb4