### PR TITLE
Add guess button for quiz submissions

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -59,6 +59,9 @@ export default function Page() {
           onChange={(e) => setGuess(e.target.value)}
           autoFocus
         />
+        <button type="submit" style={{ marginLeft: '8px' }}>
+          Guess
+        </button>
         <button
           type="button"
           onClick={() => setRevealed(true)}


### PR DESCRIPTION
## Summary
- add Guess button beside input to submit answers

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a21b17215483309e89b2c77816c62e