### PR TITLE
Reset quiz progress when switching quizzes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ export default function Page() {
     setQuizItems(shuffled);
     setGuessed([]);
     setRevealed(false);
+    setGuess('');
   }, [quizKey]);
 
   useEffect(() => {
@@ -52,7 +53,7 @@ export default function Page() {
           </option>
         ))}
       </select>
-      <Stats remaining={remaining} guesses={guessed.length} />
+      <Stats key={quizKey} remaining={remaining} guesses={guessed.length} />
       <form onSubmit={handleSubmit}>
         <input
           ref={inputRef}


### PR DESCRIPTION
## Summary
- clear current guess and reload stats when selecting a new quiz so previous progress doesn't linger

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a21d2a40588330b92c95c0cd3828c6