### PR TITLE
Auto-control timer

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,8 @@ export default function Page() {
   const [guessed, setGuessed] = useState<string[]>([]);
   const [guess, setGuess] = useState('');
   const [revealed, setRevealed] = useState(false);
+  const [timerRunning, setTimerRunning] = useState(false);
+  const [timerResetKey, setTimerResetKey] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -18,6 +20,8 @@ export default function Page() {
     setQuizItems(shuffled);
     setGuessed([]);
     setRevealed(false);
+    setTimerRunning(false);
+    setTimerResetKey((k) => k + 1);
   }, [quizKey]);
 
   useEffect(() => {
@@ -26,6 +30,9 @@ export default function Page() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!timerRunning) {
+      setTimerRunning(true);
+    }
     const normalized = guess.trim().toLowerCase();
     if (
       quizItems.some((a) => a === normalized) &&
@@ -35,6 +42,12 @@ export default function Page() {
     }
     setGuess('');
   };
+
+  useEffect(() => {
+    if (revealed || guessed.length === quizItems.length) {
+      setTimerRunning(false);
+    }
+  }, [revealed, guessed, quizItems]);
 
   const remaining = revealed ? 0 : quizItems.length - guessed.length;
 
@@ -52,7 +65,12 @@ export default function Page() {
           </option>
         ))}
       </select>
-      <Stats remaining={remaining} guesses={guessed.length} />
+      <Stats
+        remaining={remaining}
+        guesses={guessed.length}
+        running={timerRunning}
+        resetKey={timerResetKey}
+      />
       <form onSubmit={handleSubmit}>
         <input
           ref={inputRef}

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -7,12 +7,14 @@ import TotalGuesses from './TotalGuesses';
 interface StatsProps {
   remaining: number;
   guesses: number;
+  running: boolean;
+  resetKey: number;
 }
 
-export default function Stats({ remaining, guesses }: StatsProps) {
+export default function Stats({ remaining, guesses, running, resetKey }: StatsProps) {
   return (
     <div>
-      <Timer />
+      <Timer running={running} resetKey={resetKey} />
       <RemainingAnswers remaining={remaining} />
       <TotalGuesses total={guesses} />
     </div>

--- a/components/Timer.tsx
+++ b/components/Timer.tsx
@@ -2,9 +2,17 @@
 
 import { useEffect, useState } from 'react';
 
-export default function Timer() {
+interface TimerProps {
+  running: boolean;
+  resetKey: number;
+}
+
+export default function Timer({ running, resetKey }: TimerProps) {
   const [seconds, setSeconds] = useState(0);
-  const [running, setRunning] = useState(false);
+
+  useEffect(() => {
+    setSeconds(0);
+  }, [resetKey]);
 
   useEffect(() => {
     let interval: NodeJS.Timeout | undefined;
@@ -18,18 +26,5 @@ export default function Timer() {
     };
   }, [running]);
 
-  const start = () => setRunning(true);
-  const stop = () => setRunning(false);
-
-  return (
-    <div>
-      <div>Time: {seconds}s</div>
-      <button onClick={start} disabled={running}>
-        Start
-      </button>
-      <button onClick={stop} disabled={!running}>
-        Stop
-      </button>
-    </div>
-  );
+  return <div>Time: {seconds}s</div>;
 }


### PR DESCRIPTION
## Summary
- Start quiz timer on first guess and stop when quiz ends
- Reset timer when switching quizzes
- Display timer via Stats without manual controls

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a21c71b85c83309f3a170e13e2a3f2