### PR TITLE
Eliminate gaps between hidden letters

### DIFF
--- a/components/HiddenAnswer.tsx
+++ b/components/HiddenAnswer.tsx
@@ -33,7 +33,7 @@ export default function HiddenAnswer({
     );
   };
 
-  const horizontalOffset = offset?.horizontal ?? 4;
+  const horizontalOffset = offset?.horizontal ?? 0;
   const verticalOffset = offset?.vertical ?? 0;
 
   return (


### PR DESCRIPTION
## Summary
- Remove default horizontal margin between hidden answer letters to prevent visible gaps when blacked out

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a21d898ae88330b3ba39f47b1ec32c