### PR TITLE
Require hint button before revealing letters

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,6 +13,8 @@ export default function Page() {
   const [revealed, setRevealed] = useState(false);
   const [timerRunning, setTimerRunning] = useState(false);
   const [timerResetKey, setTimerResetKey] = useState(0);
+  const [hintActive, setHintActive] = useState(false);
+  const [hintsUsed, setHintsUsed] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -23,6 +25,8 @@ export default function Page() {
     setTimerRunning(false);
     setTimerResetKey((k) => k + 1);
     setGuess('');
+    setHintActive(false);
+    setHintsUsed(0);
   }, [quizKey]);
 
   useEffect(() => {
@@ -69,6 +73,7 @@ export default function Page() {
       <Stats
         remaining={remaining}
         guesses={guessed.length}
+        hints={hintsUsed}
         running={timerRunning}
         resetKey={timerResetKey}
         key={quizKey}
@@ -83,6 +88,17 @@ export default function Page() {
         />
         <button type="submit" style={{ marginLeft: '8px' }}>
           Guess
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setHintActive(true);
+            setHintsUsed((h) => h + 1);
+          }}
+          disabled={hintActive || revealed}
+          style={{ marginLeft: '8px' }}
+        >
+          Hint
         </button>
         <button
           type="button"
@@ -109,6 +125,8 @@ export default function Page() {
               <HiddenAnswer
                 answer={item}
                 reveal={showItem}
+                hintActive={hintActive}
+                onHintConsumed={() => setHintActive(false)}
               />
             </div>
           );

--- a/components/HiddenAnswer.tsx
+++ b/components/HiddenAnswer.tsx
@@ -9,12 +9,16 @@ interface HiddenAnswerProps {
     horizontal?: number;
     vertical?: number;
   };
+  hintActive?: boolean;
+  onHintConsumed?: () => void;
 }
 
 export default function HiddenAnswer({
   answer,
   reveal = false,
   offset,
+  hintActive = false,
+  onHintConsumed,
 }: HiddenAnswerProps) {
   const letters = answer.split('');
   const [revealedLetters, setRevealedLetters] = useState<boolean[]>(() =>
@@ -28,9 +32,11 @@ export default function HiddenAnswer({
   }, [reveal, letters]);
 
   const revealLetter = (index: number) => {
+    if (!hintActive || revealedLetters[index]) return;
     setRevealedLetters((prev) =>
       prev.map((val, i) => (i === index ? true : val)),
     );
+    if (onHintConsumed) onHintConsumed();
   };
 
   const horizontalOffset = offset?.horizontal ?? 0;
@@ -58,7 +64,12 @@ export default function HiddenAnswer({
             textAlign: 'center',
             lineHeight: '30px',
             border: '1px solid #000',
-            cursor: reveal || revealedLetters[idx] ? 'default' : 'pointer',
+            cursor:
+              reveal || revealedLetters[idx]
+                ? 'default'
+                : hintActive
+                ? 'pointer'
+                : 'default',
           }}
         >
           {revealedLetters[idx] ? char : ''}

--- a/components/HintsUsed.tsx
+++ b/components/HintsUsed.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+interface HintsUsedProps {
+  total: number;
+}
+
+export default function HintsUsed({ total }: HintsUsedProps) {
+  return <div>Hints: {total}</div>;
+}
+

--- a/components/Stats.tsx
+++ b/components/Stats.tsx
@@ -3,20 +3,29 @@
 import Timer from './Timer';
 import RemainingAnswers from './RemainingAnswers';
 import TotalGuesses from './TotalGuesses';
+import HintsUsed from './HintsUsed';
 
 interface StatsProps {
   remaining: number;
   guesses: number;
+  hints: number;
   running: boolean;
   resetKey: number;
 }
 
-export default function Stats({ remaining, guesses, running, resetKey }: StatsProps) {
+export default function Stats({
+  remaining,
+  guesses,
+  hints,
+  running,
+  resetKey,
+}: StatsProps) {
   return (
     <div>
       <Timer running={running} resetKey={resetKey} />
       <RemainingAnswers remaining={remaining} />
       <TotalGuesses total={guesses} />
+      <HintsUsed total={hints} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add hint activation controls so letters can only be revealed after pressing a hint button
- Track how many hints are used with a new stat component
- Display total hints used alongside existing quiz stats

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a221e9c52c83308cd9ec22b51e524a