### PR TITLE
Align quiz options into responsive columns

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,3 +2,9 @@ body {
   font-family: Arial, sans-serif;
   padding: 2rem;
 }
+
+.answers-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 8px;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,24 +93,16 @@ export default function Page() {
           Give Up
         </button>
       </form>
-      <div style={{ marginTop: '1rem' }}>
+      <div className="answers-grid" style={{ marginTop: '1rem' }}>
         {quizItems.map((item, index) => {
           const isGuessed = guessed.includes(item);
           const showItem = isGuessed || revealed;
           return (
-            <div
+            <HiddenAnswer
               key={index}
-              style={{
-                display: 'inline-block',
-                marginRight: '8px',
-                marginBottom: '8px',
-              }}
-            >
-              <HiddenAnswer
-                answer={item}
-                reveal={showItem}
-              />
-            </div>
+              answer={item}
+              reveal={showItem}
+            />
           );
         })}
       </div>


### PR DESCRIPTION
## Summary
- Display quiz answers in a responsive CSS grid so options align in columns and wrap based on screen size

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a222c669548330be2f4aff60e2ac05