### PR TITLE
reset HiddenAnswer letters when answer changes

### DIFF
--- a/components/HiddenAnswer.tsx
+++ b/components/HiddenAnswer.tsx
@@ -26,10 +26,14 @@ export default function HiddenAnswer({
   );
 
   useEffect(() => {
+    setRevealedLetters(answer.split('').map(() => reveal));
+  }, [answer, reveal]);
+
+  useEffect(() => {
     if (reveal) {
-      setRevealedLetters(letters.map(() => true));
+      setRevealedLetters(answer.split('').map(() => true));
     }
-  }, [reveal, letters]);
+  }, [reveal, answer]);
 
   const revealLetter = (index: number) => {
     if (!hintActive || revealedLetters[index]) return;


### PR DESCRIPTION
## Summary
- reset hidden answer state when `answer` prop updates
- depend on `answer` instead of derived `letters` to avoid unnecessary effect re-renders

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68a22626dcd08330a03c9b55ef8193df