### PR TITLE
Handle empty string cases in fuzzyMatch

### DIFF
--- a/utils/fuzzyMatch.ts
+++ b/utils/fuzzyMatch.ts
@@ -41,8 +41,13 @@ export function fuzzyMatch(
 
   return words.filter((word) => {
     const normalized = normalize(word);
+    const maxLength = Math.max(normalized.length, target.length);
+    if (maxLength === 0) {
+      // Both strings are empty; treat as a perfect match.
+      return true;
+    }
     const distance = levenshtein(normalized, target);
-    const similarity = 1 - distance / Math.max(normalized.length, target.length);
+    const similarity = 1 - distance / maxLength;
     return similarity >= threshold;
   });
 }


### PR DESCRIPTION
## Summary
- Avoid dividing by zero in `fuzzyMatch` by checking max string length
- Treat empty string comparisons as perfect matches

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_b_68a22637ca548330b2e2e3a75491dc23