### PR TITLE
Fix quiz answer wrapper markup

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,7 +114,7 @@ export default function Page() {
           const isGuessed = guessed.includes(item);
           const showItem = isGuessed || revealed;
           return (
-            <HiddenAnswer
+            <div
               key={index}
               style={{
                 display: 'inline-block',


### PR DESCRIPTION
## Summary
- Replace erroneous `HiddenAnswer` wrapper with a styled `div` so the quiz answers render and compile correctly

## Testing
- `npm test`
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a2265bcde4833097c71fbf8d5af4f8