### PR TITLE
feat: load quiz word lists from text files

### DIFF
--- a/quizzes/animals.ts
+++ b/quizzes/animals.ts
@@ -1,17 +1,3 @@
-export default [
-  'lion',
-  'tiger',
-  'elephant',
-  'giraffe',
-  'zebra',
-  'bear',
-  'wolf',
-  'fox',
-  'monkey',
-  'penguin',
-  'kangaroo',
-  'panda',
-  'otter',
-  'koala',
-  'rabbit',
-];
+import loadWordList from '../utils/loadWordList';
+
+export default loadWordList('animals');

--- a/quizzes/countries.ts
+++ b/quizzes/countries.ts
@@ -1,12 +1,3 @@
-export default [
-  'canada',
-  'brazil',
-  'france',
-  'india',
-  'australia',
-  'kenya',
-  'japan',
-  'mexico',
-  'germany',
-  'egypt',
-];
+import loadWordList from '../utils/loadWordList';
+
+export default loadWordList('countries');

--- a/quizzes/foods.ts
+++ b/quizzes/foods.ts
@@ -1,12 +1,3 @@
-export default [
-  'pizza',
-  'sushi',
-  'hamburger',
-  'spaghetti',
-  'curry',
-  'sandwich',
-  'salad',
-  'tacos',
-  'chocolate',
-  'pancake',
-];
+import loadWordList from '../utils/loadWordList';
+
+export default loadWordList('foods');

--- a/utils/loadWordList.ts
+++ b/utils/loadWordList.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Loads a word list from the `word-lists` directory.
+ * Each line is trimmed, lowercased, and empty lines are removed.
+ *
+ * @param name Basename of the word list file (without extension).
+ * @returns Array of normalized words.
+ */
+export default function loadWordList(name: string): string[] {
+  const filePath = path.join(process.cwd(), 'word-lists', `${name}.txt`);
+  const content = fs.readFileSync(filePath, 'utf-8');
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim().toLowerCase())
+    .filter(Boolean);
+}


### PR DESCRIPTION
## Summary
- add `loadWordList` utility to read word lists from `word-lists/*.txt`
- update quiz modules to load lists via the new utility

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a22607cb7c8330923223606d75d776