### PR TITLE
refactor: simplify answer wrapper

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,3 +8,9 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   gap: 8px;
 }
+
+.answer-wrapper {
+  display: inline-block;
+  margin-right: 8px;
+  margin-bottom: 8px;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,14 +114,7 @@ export default function Page() {
           const isGuessed = guessed.includes(item);
           const showItem = isGuessed || revealed;
           return (
-            <HiddenAnswer
-              key={index}
-              style={{
-                display: 'inline-block',
-                marginRight: '8px',
-                marginBottom: '8px',
-              }}
-            >
+            <div key={index} className="answer-wrapper">
               <HiddenAnswer
                 answer={item}
                 reveal={showItem}


### PR DESCRIPTION
## Summary
- replace wrapper `HiddenAnswer` with `div` and move inline styles to CSS class
- keep single `HiddenAnswer` for displaying quiz answers

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a2261287208330a198ce16f38903d8