### PR TITLE
feat: add optional fuzzy answer correction

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import Stats from '../components/Stats';
 import HiddenAnswer from '../components/HiddenAnswer';
 import { QUIZZES, QuizKey } from '../quizzes';
+import { useFuzzyGuess } from '../hooks/useFuzzyGuess';
 
 export default function Page() {
   const [quizKey, setQuizKey] = useState<QuizKey>('animals');
@@ -15,6 +16,7 @@ export default function Page() {
   const [timerResetKey, setTimerResetKey] = useState(0);
   const [hintActive, setHintActive] = useState(false);
   const [hintsUsed, setHintsUsed] = useState(0);
+  const { apply: applyFuzzy, FuzzyToggle, CorrectedMessage } = useFuzzyGuess();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -39,12 +41,9 @@ export default function Page() {
     if (!timerRunning) {
       setTimerRunning(true);
     }
-    const normalized = guess.trim().toLowerCase();
-    if (
-      quizItems.some((a) => a === normalized) &&
-      !guessed.includes(normalized)
-    ) {
-      setGuessed([...guessed, normalized]);
+    const accepted = applyFuzzy(guess, quizItems, guessed);
+    if (quizItems.some((a) => a === accepted) && !guessed.includes(accepted)) {
+      setGuessed([...guessed, accepted]);
     }
     setGuess('');
   };
@@ -109,7 +108,9 @@ export default function Page() {
         >
           Give Up
         </button>
+        <FuzzyToggle />
       </form>
+      <CorrectedMessage />
       <div className="answers-grid" style={{ marginTop: '1rem' }}>
         {quizItems.map((item) => {
           const isGuessed = guessed.includes(item);

--- a/hooks/useFuzzyGuess.ts
+++ b/hooks/useFuzzyGuess.ts
@@ -1,0 +1,47 @@
+import { useEffect, useState } from 'react';
+import { fuzzyMatch } from '../utils/fuzzyMatch';
+
+export function useFuzzyGuess() {
+  const [useFuzzy, setUseFuzzy] = useState(false);
+  const [corrected, setCorrected] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (corrected) {
+      const t = setTimeout(() => setCorrected(null), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [corrected]);
+
+  function apply(guess: string, quizItems: string[], guessed: string[]) {
+    const normalized = guess.trim().toLowerCase();
+    if (!useFuzzy || quizItems.includes(normalized)) {
+      return normalized;
+    }
+    const remaining = quizItems.filter((item) => !guessed.includes(item));
+    const matches = fuzzyMatch(remaining, normalized, 0.8);
+    if (matches.length > 0) {
+      setCorrected(matches[0]);
+      return matches[0];
+    }
+    return normalized;
+  }
+
+  const FuzzyToggle = () => (
+    <label style={{ marginLeft: '8px' }}>
+      <input
+        type="checkbox"
+        checked={useFuzzy}
+        onChange={(e) => setUseFuzzy(e.target.checked)}
+      />{' '}
+      Use fuzzy search
+    </label>
+  );
+
+  const CorrectedMessage = () =>
+    corrected ? (
+      <div style={{ marginTop: '8px' }}>Auto-corrected to: {corrected}</div>
+    ) : null;
+
+  return { apply, FuzzyToggle, CorrectedMessage };
+}
+


### PR DESCRIPTION
## Summary
- move fuzzy answer correction into a reusable `useFuzzyGuess` hook
- landing page imports the hook to enable toggling and display corrections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a238bf76388330a9baf121e19f8332