### PR TITLE
feat: allow per-quiz shuffling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,9 +21,12 @@ export default function Page() {
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
-    const uniqueItems = Array.from(new Set(QUIZZES[quizKey]));
-    const shuffled = uniqueItems.sort(() => Math.random() - 0.5);
-    setQuizItems(shuffled);
+    const { items, shuffle } = QUIZZES[quizKey];
+    const uniqueItems = Array.from(new Set(items));
+    const randomized = shuffle
+      ? uniqueItems.sort(() => Math.random() - 0.5)
+      : uniqueItems;
+    setQuizItems(randomized);
     setGuessed([]);
     setRevealed(false);
     setTimerRunning(false);

--- a/quizzes/index.ts
+++ b/quizzes/index.ts
@@ -3,11 +3,16 @@ import countries from './countries';
 import foods from './foods';
 import pokemonData from './pokemon';
 
-export const QUIZZES = {
-  animals,
-  countries,
-  foods,
-  pokemon: pokemonData.map((p) => p.name),
+interface QuizConfig {
+  items: string[];
+  shuffle: boolean;
+}
+
+export const QUIZZES: Record<string, QuizConfig> = {
+  animals: { items: animals, shuffle: true },
+  countries: { items: countries, shuffle: true },
+  foods: { items: foods, shuffle: true },
+  pokemon: { items: pokemonData.map((p) => p.name), shuffle: false },
 };
 
 export type QuizKey = keyof typeof QUIZZES;


### PR DESCRIPTION
## Summary
- let each quiz declare whether its items are shuffled
- read shuffle setting from quiz data and remove Pokémon-only toggle

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Expected '>', got 'style' in useFuzzyGuess.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68a240bbccdc8330bdf934360054cd96