### PR TITLE
Add optional Pokémon type hints to quiz answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Select a quiz topic from the drop-down and type the names to guess them. If you 
 
 Pokemon type icons are provided by [pokemon-type-svg-icons](https://github.com/duiker101/pokemon-type-svg-icons).
 
+In the Pokémon quiz, toggle **Show types** to display each Pokémon's type icons next to its answer.
+
 ## Getting Started
 
 Install dependencies (requires internet access):

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ export default function Page() {
   const [timerResetKey, setTimerResetKey] = useState(0);
   const [hintActive, setHintActive] = useState(false);
   const [hintsUsed, setHintsUsed] = useState(0);
+  const [showTypes, setShowTypes] = useState(false);
   const { apply: applyFuzzy, FuzzyToggle, CorrectedMessage } = useFuzzyGuess();
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -34,6 +35,7 @@ export default function Page() {
     setGuess('');
     setHintActive(false);
     setHintsUsed(0);
+    setShowTypes(false);
   }, [quizKey]);
 
   useEffect(() => {
@@ -104,16 +106,26 @@ export default function Page() {
         >
           Hint
         </button>
-        <button
-          type="button"
-          onClick={() => setRevealed(true)}
-          disabled={revealed}
-          style={{ marginLeft: '8px' }}
-        >
-          Give Up
-        </button>
-        <FuzzyToggle />
-      </form>
+          <button
+            type="button"
+            onClick={() => setRevealed(true)}
+            disabled={revealed}
+            style={{ marginLeft: '8px' }}
+          >
+            Give Up
+          </button>
+          {quizKey === 'pokemon' && (
+            <label style={{ marginLeft: '8px' }}>
+              <input
+                type="checkbox"
+                checked={showTypes}
+                onChange={(e) => setShowTypes(e.target.checked)}
+              />{' '}
+              Show types
+            </label>
+          )}
+          <FuzzyToggle />
+        </form>
       <CorrectedMessage />
       <div className="answers-grid" style={{ marginTop: '1rem' }}>
         {quizItems.map((item) => {
@@ -138,7 +150,7 @@ export default function Page() {
                 hintActive={hintActive}
                 onHintConsumed={() => setHintActive(false)}
               />
-              {quizKey === 'pokemon' && showItem && (
+              {quizKey === 'pokemon' && (showItem || showTypes) && (
                 <PokemonTypeIcons types={types} />
               )}
             </div>


### PR DESCRIPTION
## Summary
- add a `Show types` checkbox for the Pokémon quiz
- show Pokémon type icons when the toggle is enabled or the answer is revealed
- document the new toggle in the README

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a246c2e1a4833088a066044c7bf414