### PR TITLE
Display Pokédex numbers in Pokémon quiz answers

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -135,6 +135,10 @@ export default function Page() {
             quizKey === 'pokemon'
               ? pokemonData.find((p) => p.name === item)?.types ?? []
               : [];
+          const number =
+            quizKey === 'pokemon'
+              ? pokemonData.findIndex((p) => p.name === item) + 1
+              : undefined;
           return (
             <div
               key={item}
@@ -144,6 +148,11 @@ export default function Page() {
                 marginBottom: '8px',
               }}
             >
+              {quizKey === 'pokemon' && (
+                <span style={{ marginRight: '4px' }}>
+                  {`#${String(number).padStart(3, '0')}`}
+                </span>
+              )}
               <HiddenAnswer
                 answer={item}
                 reveal={showItem}


### PR DESCRIPTION
## Summary
- Show Pokédex numbers alongside each Pokémon entry in the quiz

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68a249e4e13c83309092451147ed11d8