### PR TITLE
Fix Pokémon type icon placement

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,7 +143,8 @@ export default function Page() {
             <div
               key={item}
               style={{
-                display: 'inline-block',
+                display: 'inline-flex',
+                alignItems: 'center',
                 marginRight: '8px',
                 marginBottom: '8px',
               }}
@@ -153,15 +154,15 @@ export default function Page() {
                   {`#${String(number).padStart(3, '0')}`}
                 </span>
               )}
+              {quizKey === 'pokemon' && (showItem || showTypes) && (
+                <PokemonTypeIcons types={types} />
+              )}
               <HiddenAnswer
                 answer={item}
                 reveal={showItem}
                 hintActive={hintActive}
                 onHintConsumed={() => setHintActive(false)}
               />
-              {quizKey === 'pokemon' && (showItem || showTypes) && (
-                <PokemonTypeIcons types={types} />
-              )}
             </div>
           );
         })}

--- a/components/PokemonTypeIcons.tsx
+++ b/components/PokemonTypeIcons.tsx
@@ -6,7 +6,7 @@ interface PokemonTypeIconsProps {
 
 export default function PokemonTypeIcons({ types }: PokemonTypeIconsProps) {
   return (
-    <div style={{ display: 'flex', gap: '4px', marginTop: '4px' }}>
+    <div style={{ display: 'inline-flex', gap: '4px', marginLeft: '4px' }}>
       {types.map((type) => (
         <Image
           key={type}


### PR DESCRIPTION
## Summary
- show Pokémon type icons inline next to number
- align quiz item row with flex so icons appear before hidden answer

## Testing
- `npm test`
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68a2561f2cb08330adbf8995d277dc18