### PR TITLE
Fix overlapping Pokémon type icons

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -143,8 +143,7 @@ export default function Page() {
             <div
               key={item}
               style={{
-                display: 'inline-flex',
-                alignItems: 'center',
+                display: 'inline-block',
                 marginRight: '8px',
                 marginBottom: '8px',
               }}
@@ -154,15 +153,15 @@ export default function Page() {
                   {`#${String(number).padStart(3, '0')}`}
                 </span>
               )}
-              {quizKey === 'pokemon' && (showItem || showTypes) && (
-                <PokemonTypeIcons types={types} />
-              )}
               <HiddenAnswer
                 answer={item}
                 reveal={showItem}
                 hintActive={hintActive}
                 onHintConsumed={() => setHintActive(false)}
               />
+              {quizKey === 'pokemon' && (showItem || showTypes) && (
+                <PokemonTypeIcons types={types} />
+              )}
             </div>
           );
         })}

--- a/components/PokemonTypeIcons.tsx
+++ b/components/PokemonTypeIcons.tsx
@@ -6,7 +6,7 @@ interface PokemonTypeIconsProps {
 
 export default function PokemonTypeIcons({ types }: PokemonTypeIconsProps) {
   return (
-    <div style={{ display: 'inline-flex', gap: '4px', marginLeft: '4px' }}>
+    <div style={{ display: 'flex', gap: '4px', marginTop: '4px' }}>
       {types.map((type) => (
         <Image
           key={type}
@@ -14,6 +14,7 @@ export default function PokemonTypeIcons({ types }: PokemonTypeIconsProps) {
           alt={`${type} type icon`}
           width={20}
           height={20}
+          style={{ backgroundColor: '#fff', borderRadius: '4px' }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Revert type icon placement to avoid overlapping with answers
- Give Pokémon type icons a background color for better visibility

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_b_68a258ff6edc8330afdcb8106a84d1c7