### PR TITLE
Add guess feedback messages

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import Stats from '../components/Stats';
 import HiddenAnswer from '../components/HiddenAnswer';
-import { useFuzzyGuess } from '../hooks/useFuzzyGuess';
+import { useGuessFeedback } from '../hooks/useGuessFeedback';
 import PokemonTypeIcons from '../components/PokemonTypeIcons';
 import { QUIZZES, QuizKey, pokemonData } from '../quizzes';
 
@@ -18,7 +18,11 @@ export default function Page() {
   const [hintActive, setHintActive] = useState(false);
   const [hintsUsed, setHintsUsed] = useState(0);
   const [showTypes, setShowTypes] = useState(false);
-  const { apply: applyFuzzy, FuzzyToggle, CorrectedMessage } = useFuzzyGuess();
+  const { handleGuess, FuzzyToggle, GuessMessage } = useGuessFeedback(
+    quizItems,
+    guessed,
+    setGuessed
+  );
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -47,10 +51,7 @@ export default function Page() {
     if (!timerRunning) {
       setTimerRunning(true);
     }
-    const accepted = applyFuzzy(guess, quizItems, guessed);
-    if (quizItems.some((a) => a === accepted) && !guessed.includes(accepted)) {
-      setGuessed([...guessed, accepted]);
-    }
+    handleGuess(guess);
     setGuess('');
   };
 
@@ -126,7 +127,7 @@ export default function Page() {
           )}
           <FuzzyToggle />
         </form>
-      <CorrectedMessage />
+      <GuessMessage />
       <div className="answers-grid" style={{ marginTop: '1rem' }}>
         {quizItems.map((item) => {
           const isGuessed = guessed.includes(item);

--- a/hooks/useFuzzyGuess.tsx
+++ b/hooks/useFuzzyGuess.tsx
@@ -3,27 +3,34 @@ import { fuzzyMatch } from '../utils/fuzzyMatch';
 
 export function useFuzzyGuess() {
   const [useFuzzy, setUseFuzzy] = useState(false);
-  const [corrected, setCorrected] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    if (corrected) {
-      const t = setTimeout(() => setCorrected(null), 3000);
+    if (message) {
+      const t = setTimeout(() => setMessage(null), 3000);
       return () => clearTimeout(t);
     }
-  }, [corrected]);
+  }, [message]);
 
-  function apply(guess: string, quizItems: string[], guessed: string[]) {
+  function apply(
+    guess: string,
+    quizItems: string[],
+    guessed: string[]
+  ): { accepted: string; correction?: string } {
     const normalized = guess.trim().toLowerCase();
     if (!useFuzzy || quizItems.includes(normalized)) {
-      return normalized;
+      return { accepted: normalized };
     }
     const remaining = quizItems.filter((item) => !guessed.includes(item));
     const matches = fuzzyMatch(remaining, normalized, 0.8);
     if (matches.length > 0) {
-      setCorrected(matches[0]);
-      return matches[0];
+      return { accepted: matches[0], correction: matches[0] };
     }
-    return normalized;
+    return { accepted: normalized };
+  }
+
+  function showMessage(msg: string) {
+    setMessage(msg);
   }
 
   const FuzzyToggle = () => (
@@ -37,11 +44,9 @@ export function useFuzzyGuess() {
     </label>
   );
 
-  const CorrectedMessage = () =>
-    corrected ? (
-      <div style={{ marginTop: '8px' }}>Auto-corrected to: {corrected}</div>
-    ) : null;
+  const GuessMessage = () =>
+    message ? <div style={{ marginTop: '8px' }}>{message}</div> : null;
 
-  return { apply, FuzzyToggle, CorrectedMessage };
+  return { apply, FuzzyToggle, GuessMessage, showMessage };
 }
 

--- a/hooks/useGuessFeedback.tsx
+++ b/hooks/useGuessFeedback.tsx
@@ -1,0 +1,36 @@
+import { Dispatch, SetStateAction, useCallback } from 'react';
+import { useFuzzyGuess } from './useFuzzyGuess';
+
+export function useGuessFeedback(
+  quizItems: string[],
+  guessed: string[],
+  setGuessed: Dispatch<SetStateAction<string[]>>
+) {
+  const { apply: applyFuzzy, FuzzyToggle, GuessMessage, showMessage } =
+    useFuzzyGuess();
+
+  const handleGuess = useCallback(
+    (rawGuess: string) => {
+      const { accepted, correction } = applyFuzzy(rawGuess, quizItems, guessed);
+      let msg = '';
+      if (correction) {
+        msg += `Auto-corrected to: ${correction}. `;
+      }
+      if (quizItems.includes(accepted)) {
+        if (guessed.includes(accepted)) {
+          msg += 'Already guessed!';
+        } else {
+          setGuessed([...guessed, accepted]);
+          msg += 'Correct!';
+        }
+      } else {
+        msg += 'Wrong answer!';
+      }
+      showMessage(msg.trim());
+    },
+    [applyFuzzy, guessed, quizItems, setGuessed, showMessage]
+  );
+
+  return { handleGuess, FuzzyToggle, GuessMessage };
+}
+


### PR DESCRIPTION
## Summary
- extend fuzzy guess hook with generic feedback messaging
- show messages for auto-correction, repeated guesses, correct answers, and wrong answers
- refactor guess handling into reusable hook

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a24e0364208330abd318897e8ba320