### PR TITLE
Adjust fuzzy match thresholds and add close feedback

### DIFF
--- a/hooks/useFuzzyGuess.tsx
+++ b/hooks/useFuzzyGuess.tsx
@@ -16,15 +16,19 @@ export function useFuzzyGuess() {
     guess: string,
     quizItems: string[],
     guessed: string[]
-  ): { accepted: string; correction?: string } {
+  ): { accepted: string; correction?: string; isClose?: boolean } {
     const normalized = guess.trim().toLowerCase();
     if (!useFuzzy || quizItems.includes(normalized)) {
       return { accepted: normalized };
     }
     const remaining = quizItems.filter((item) => !guessed.includes(item));
-    const matches = fuzzyMatch(remaining, normalized, 0.8);
+    const matches = fuzzyMatch(remaining, normalized, 0.7);
     if (matches.length > 0) {
       return { accepted: matches[0], correction: matches[0] };
+    }
+    const closeMatches = fuzzyMatch(remaining, normalized, 0.6);
+    if (closeMatches.length > 0) {
+      return { accepted: normalized, isClose: true };
     }
     return { accepted: normalized };
   }

--- a/hooks/useGuessFeedback.tsx
+++ b/hooks/useGuessFeedback.tsx
@@ -11,7 +11,11 @@ export function useGuessFeedback(
 
   const handleGuess = useCallback(
     (rawGuess: string) => {
-      const { accepted, correction } = applyFuzzy(rawGuess, quizItems, guessed);
+      const { accepted, correction, isClose } = applyFuzzy(
+        rawGuess,
+        quizItems,
+        guessed
+      );
       let msg = '';
       if (correction) {
         msg += `Auto-corrected to: ${correction}. `;
@@ -24,7 +28,7 @@ export function useGuessFeedback(
           msg += 'Correct!';
         }
       } else {
-        msg += 'Wrong answer!';
+        msg += isClose ? 'Close!' : 'Wrong answer!';
       }
       showMessage(msg.trim());
     },


### PR DESCRIPTION
## Summary
- Accept fuzzy guesses when similarity is at least 70%
- Mark guesses between 60–70% similarity as "Close" instead of "Wrong answer"

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a261a2e6488330a01f2f73051ad897