### PR TITLE
Set Pokémon as default quiz and make type icons visible

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ import PokemonTypeIcons from '../components/PokemonTypeIcons';
 import { QUIZZES, QuizKey, pokemonData } from '../quizzes';
 
 export default function Page() {
-  const [quizKey, setQuizKey] = useState<QuizKey>('animals');
+  const [quizKey, setQuizKey] = useState<QuizKey>('pokemon');
   const [quizItems, setQuizItems] = useState<string[]>([]);
   const [guessed, setGuessed] = useState<string[]>([]);
   const [guess, setGuess] = useState('');

--- a/components/PokemonTypeIcons.tsx
+++ b/components/PokemonTypeIcons.tsx
@@ -14,7 +14,7 @@ export default function PokemonTypeIcons({ types }: PokemonTypeIconsProps) {
           alt={`${type} type icon`}
           width={20}
           height={20}
-          style={{ backgroundColor: '#fff', borderRadius: '4px' }}
+          style={{ filter: 'invert(1)', borderRadius: '4px' }}
         />
       ))}
     </div>


### PR DESCRIPTION
## Summary
- Default to the Pokémon quiz on load
- Invert Pokémon type icons so they stand out against the page

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68a261298fb4833087fdbce4c69f537e