### PR TITLE
Use unguessed answers for fuzzy search

### DIFF
--- a/hooks/useFuzzyGuess.tsx
+++ b/hooks/useFuzzyGuess.tsx
@@ -17,11 +17,13 @@ export function useFuzzyGuess() {
     quizItems: string[],
     guessed: string[]
   ): { accepted: string; correction?: string; isClose?: boolean } {
-    const normalized = guess.trim().toLowerCase();
-    if (!useFuzzy || quizItems.includes(normalized)) {
+    const normalize = (s: string) => s.trim().toLowerCase();
+    const normalized = normalize(guess);
+    const normalizedItems = quizItems.map(normalize);
+    if (!useFuzzy || normalizedItems.includes(normalized)) {
       return { accepted: normalized };
     }
-    const remaining = quizItems.filter((item) => !guessed.includes(item));
+    const remaining = normalizedItems.filter((item) => !guessed.includes(item));
     const matches = fuzzyMatch(remaining, normalized, 0.7);
     if (matches.length > 0) {
       return { accepted: matches[0], correction: matches[0] };


### PR DESCRIPTION
## Summary
- Normalize quiz items and filter guessed entries before fuzzy matching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a268cc82488330b9f632fbafcb4105