### PR TITLE
Add option to hide guessed answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Pokemon type icons are provided by [pokemon-type-svg-icons](https://github.com/d
 
 In the Pokémon quiz, toggle **Show types** to display each Pokémon's type icons next to its answer.
 
+Use **Hide guessed** if you want to remove answers you've already guessed from the list.
+
 ## Getting Started
 
 Install dependencies (requires internet access):

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,6 +18,7 @@ export default function Page() {
   const [hintActive, setHintActive] = useState(false);
   const [hintsUsed, setHintsUsed] = useState(0);
   const [showTypes, setShowTypes] = useState(false);
+  const [hideGuessed, setHideGuessed] = useState(false);
   const { handleGuess, FuzzyToggle, GuessMessage } = useGuessFeedback(
     quizItems,
     guessed,
@@ -40,6 +41,7 @@ export default function Page() {
     setHintActive(false);
     setHintsUsed(0);
     setShowTypes(false);
+    setHideGuessed(false);
   }, [quizKey]);
 
   useEffect(() => {
@@ -125,12 +127,23 @@ export default function Page() {
               Show types
             </label>
           )}
+          <label style={{ marginLeft: '8px' }}>
+            <input
+              type="checkbox"
+              checked={hideGuessed}
+              onChange={(e) => setHideGuessed(e.target.checked)}
+            />{' '}
+            Hide guessed
+          </label>
           <FuzzyToggle />
         </form>
       <GuessMessage />
       <div className="answers-grid" style={{ marginTop: '1rem' }}>
         {quizItems.map((item) => {
           const isGuessed = guessed.includes(item);
+          if (hideGuessed && isGuessed && !revealed) {
+            return null;
+          }
           const showItem = isGuessed || revealed;
           const types =
             quizKey === 'pokemon'


### PR DESCRIPTION
## Summary
- add checkbox to hide guessed answers during quizzes
- document "Hide guessed" option in README

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a268b4b8e48330924d3b4d021a67d4