### PR TITLE
feat: reduce guessed answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pokemon type icons are provided by [pokemon-type-svg-icons](https://github.com/d
 
 In the Pokémon quiz, toggle **Show types** to display each Pokémon's type icons next to its answer.
 
-Use **Hide guessed** if you want to remove answers you've already guessed from the list.
+Use **Reduce guessed answers** to hide a guessed answer only when its neighbors have been guessed as well.
 
 ## Getting Started
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Page() {
   const [hintActive, setHintActive] = useState(false);
   const [hintsUsed, setHintsUsed] = useState(0);
   const [showTypes, setShowTypes] = useState(false);
-  const [hideGuessed, setHideGuessed] = useState(false);
+  const [reduceGuessed, setReduceGuessed] = useState(false);
   const { handleGuess, FuzzyToggle, GuessMessage } = useGuessFeedback(
     quizItems,
     guessed,
@@ -41,7 +41,7 @@ export default function Page() {
     setHintActive(false);
     setHintsUsed(0);
     setShowTypes(false);
-    setHideGuessed(false);
+    setReduceGuessed(false);
   }, [quizKey]);
 
   useEffect(() => {
@@ -130,19 +130,25 @@ export default function Page() {
           <label style={{ marginLeft: '8px' }}>
             <input
               type="checkbox"
-              checked={hideGuessed}
-              onChange={(e) => setHideGuessed(e.target.checked)}
+              checked={reduceGuessed}
+              onChange={(e) => setReduceGuessed(e.target.checked)}
             />{' '}
-            Hide guessed
+            Reduce guessed answers
           </label>
           <FuzzyToggle />
         </form>
       <GuessMessage />
       <div className="answers-grid" style={{ marginTop: '1rem' }}>
-        {quizItems.map((item) => {
+        {quizItems.map((item, index) => {
           const isGuessed = guessed.includes(item);
-          if (hideGuessed && isGuessed && !revealed) {
-            return null;
+          if (reduceGuessed && isGuessed && !revealed) {
+            const prevGuessed =
+              index === 0 || guessed.includes(quizItems[index - 1]);
+            const nextGuessed =
+              index === quizItems.length - 1 || guessed.includes(quizItems[index + 1]);
+            if (prevGuessed && nextGuessed) {
+              return null;
+            }
           }
           const showItem = isGuessed || revealed;
           const types =


### PR DESCRIPTION
## Summary
- replace Hide guessed with Reduce guessed answers
- hide guessed entries only when their neighbors are also guessed
- document the new reduce guessed behavior

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a26bf5b0108330847944a5e8311b32