### PR TITLE
Add hover titles for Pokémon type icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Select a quiz topic from the drop-down and type the names to guess them. If you 
 Pokemon type icons are provided by [pokemon-type-svg-icons](https://github.com/duiker101/pokemon-type-svg-icons).
 
 In the Pokémon quiz, toggle **Show types** to display each Pokémon's type icons next to its answer.
+Hover over a type icon to see its type name.
 
 Use **Hide guessed** if you want to remove answers you've already guessed from the list.
 

--- a/components/PokemonTypeIcons.tsx
+++ b/components/PokemonTypeIcons.tsx
@@ -12,6 +12,7 @@ export default function PokemonTypeIcons({ types }: PokemonTypeIconsProps) {
           key={type}
           src={`/type-icons/${type}.svg`}
           alt={`${type} type icon`}
+          title={type}
           width={20}
           height={20}
           style={{ filter: 'invert(1)', borderRadius: '4px' }}


### PR DESCRIPTION
## Summary
- show type names when hovering Pokémon type icons
- document hovering of type icons

## Testing
- `npm test`
- `npm run lint` *(fails: requires configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68a26b22b91c8330b9714c787180a6c0