### PR TITLE
Remove border from revealed answer letters

### DIFF
--- a/components/HiddenAnswer.tsx
+++ b/components/HiddenAnswer.tsx
@@ -67,7 +67,7 @@ export default function HiddenAnswer({
             color: '#000',
             textAlign: 'center',
             lineHeight: '30px',
-            border: '1px solid #000',
+            border: revealedLetters[idx] ? 'none' : '1px solid #000',
             cursor:
               reveal || revealedLetters[idx]
                 ? 'default'


### PR DESCRIPTION
## Summary
- hide letter border when letters are revealed

## Testing
- `npm test`
- `npm run lint` *(fails: requires ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_b_68a26b9d402083308d9f0a30a1b24149